### PR TITLE
(GH-19) Return list of created packages from Pack command

### DIFF
--- a/src/Cake.Npm/NpmPackAliases.cs
+++ b/src/Cake.Npm/NpmPackAliases.cs
@@ -15,9 +15,11 @@ namespace Cake.Npm
     public static class NpmPackAliases
     {
         /// <summary>
-        /// Creates a npm package from the current folder.
+        /// Creates a npm package from the current working directory.
+        /// Package will be created in the current working directory.
         /// </summary>
         /// <param name="context">The context.</param>
+        /// <returns>List of created packages.</returns>
         /// <example>
         /// <code>
         /// <![CDATA[
@@ -39,10 +41,12 @@ namespace Cake.Npm
 
         /// <summary>
         /// Creates a npm package from a specific source.
+        /// Package will be created in the current working directory.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="source">Source to pack. Can be anything that is installable by npm, like
         /// a package folder, tarball, tarball url, name@tag, name@version, name, or scoped name.</param>
+        /// <returns>List of created packages.</returns>
         /// <example>
         /// <code>
         /// <![CDATA[
@@ -100,9 +104,11 @@ namespace Cake.Npm
 
         /// <summary>
         /// Creates a npm package using the specified settings.
+        /// Package will be created in the current working directory.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="settings">The settings.</param>
+        /// <returns>List of created packages.</returns>
         /// <example>
         /// <code>
         /// <![CDATA[

--- a/src/Cake.Npm/NpmPackAliases.cs
+++ b/src/Cake.Npm/NpmPackAliases.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using Cake.Core;
 using Cake.Core.Annotations;
+using Cake.Core.IO;
 using Cake.Npm.Pack;
 
 namespace Cake.Npm
@@ -25,14 +27,14 @@ namespace Cake.Npm
         /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Pack")]
-        public static void NpmPack(this ICakeContext context)
+        public static IEnumerable<FilePath> NpmPack(this ICakeContext context)
         {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
 
-            context.NpmPack(new NpmPackSettings());
+            return context.NpmPack(new NpmPackSettings());
         }
 
         /// <summary>
@@ -50,7 +52,7 @@ namespace Cake.Npm
         /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Pack")]
-        public static void NpmPack(this ICakeContext context, string source)
+        public static IEnumerable<FilePath> NpmPack(this ICakeContext context, string source)
         {
             if (context == null)
             {
@@ -62,7 +64,7 @@ namespace Cake.Npm
                 throw new ArgumentNullException(nameof(source));
             }
 
-            context.NpmPack(new NpmPackSettings { Source = source });
+            return context.NpmPack(new NpmPackSettings { Source = source });
         }
 
         /// <summary>
@@ -115,7 +117,7 @@ namespace Cake.Npm
         /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Pack")]
-        public static void NpmPack(this ICakeContext context, NpmPackSettings settings)
+        public static IEnumerable<FilePath> NpmPack(this ICakeContext context, NpmPackSettings settings)
         {
             if (context == null)
             {
@@ -130,7 +132,7 @@ namespace Cake.Npm
             AddinInformation.LogVersionInformation(context.Log);
 
             var packer = new NpmPacker(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, context.Log);
-            packer.Pack(settings);
+            return packer.Pack(settings);
         }
     }
 }

--- a/src/Cake.Npm/NpmTool.cs
+++ b/src/Cake.Npm/NpmTool.cs
@@ -69,6 +69,17 @@
         /// <param name="settings">The settings.</param>
         protected void RunCore(TSettings settings)
         {
+            RunCore(settings, null, null);
+        }
+
+        /// <summary>
+        /// Runs npm.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="processSettings">The process settings. <c>null</c> for default settings.</param>
+        /// <param name="postAction">Action which should be executed after running npm. <c>null</c> for no action.</param>
+        protected void RunCore(TSettings settings, ProcessSettings processSettings, Action<IProcess> postAction)
+        {
             if (settings == null)
             {
                 throw new ArgumentNullException(nameof(settings));
@@ -80,7 +91,7 @@
             }
 
             var args = GetArguments(settings);
-            Run(settings, args);
+            Run(settings, args, processSettings, postAction);
         }
 
         /// <summary>

--- a/src/Cake.Npm/Pack/NpmPacker.cs
+++ b/src/Cake.Npm/Pack/NpmPacker.cs
@@ -1,6 +1,8 @@
 ﻿namespace Cake.Npm.Pack
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using Core;
     using Core.Diagnostics;
     using Core.IO;
@@ -33,14 +35,34 @@
         /// Creates a npm package from the specified settings.
         /// </summary>
         /// <param name="settings">The settings.</param>
-        public void Pack(NpmPackSettings settings)
+        /// <returns>List of created packages.</returns>
+        public IEnumerable<FilePath> Pack(NpmPackSettings settings)
         {
             if (settings == null)
             {
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            RunCore(settings);
+            var processSettings = new ProcessSettings
+            {
+                Arguments = GetArguments(settings),
+                RedirectStandardOutput = true
+            };
+
+            var packages = new List<FilePath>();
+            RunCore(
+                settings,
+                processSettings,
+                process => {
+                    var output = process.GetStandardOutput();
+                    if (output != null)
+                    {
+                        packages.AddRange(
+                            output.Select(x => GetWorkingDirectory(settings).GetFilePath(new FilePath(x))));
+                    }
+                });
+
+            return packages;
         }
     }
 }

--- a/src/Cake.Npm/Pack/NpmPacker.cs
+++ b/src/Cake.Npm/Pack/NpmPacker.cs
@@ -54,11 +54,14 @@
                 settings,
                 processSettings,
                 process => {
-                    var output = process.GetStandardOutput();
-                    if (output != null)
+                    if (process.GetExitCode() == 0)
                     {
-                        packages.AddRange(
-                            output.Select(x => GetWorkingDirectory(settings).GetFilePath(new FilePath(x))));
+                        var output = process.GetStandardOutput();
+                        if (output != null)
+                        {
+                            packages.AddRange(
+                                output.Select(x => GetWorkingDirectory(settings).GetFilePath(new FilePath(x))));
+                        }
                     }
                 });
 


### PR DESCRIPTION
Returns a list of created from the Pack command. Fixes #19 

Unfortunately there seem to be issues with `RedirectStandardOutput` not working correctly in Cake 0.17.0. It works fine in current Cake 0.18.0 build though. Therefore we need to wait with merging this until Cake 0.18.0 is released.