### PR TITLE
Added NoProxy method to NpmInstallSettings

### DIFF
--- a/Cake.Npm.sln
+++ b/Cake.Npm.sln
@@ -1,13 +1,18 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cake.Npm", "src\Cake.Npm\Cake.Npm.csproj", "{6AD0659E-11CA-44DD-89B8-D02769E31AFE}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{7ADA99C9-D5AA-49DB-B197-AC014206BF2A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cake.Npm.Tests", "src\Cake.Npm.Tests\Cake.Npm.Tests.csproj", "{72AE40AF-1DD9-426F-AD33-75F2DF1EA022}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{98182B56-5168-4DBD-A61C-74511B3A01F9}"
+	ProjectSection(SolutionItems) = preProject
+		cake.config = cake.config
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Cake.Npm.Tests/NpmRunnerTests.cs
+++ b/src/Cake.Npm.Tests/NpmRunnerTests.cs
@@ -1,43 +1,57 @@
 ﻿
-using System;
 using Cake.Core.Diagnostics;
 using Shouldly;
-
+using System;
 using Xunit;
 
-namespace Cake.Npm.Tests {
-	public class NpmRunnerTests {
-		private readonly NpmRunnerFixture fixture;
+namespace Cake.Npm.Tests
+{
+    public class NpmRunnerTests
+    {
+        private readonly NpmRunnerFixture fixture;
 
-		public NpmRunnerTests() {
-			this.fixture = new NpmRunnerFixture();
-		}
+        public NpmRunnerTests()
+        {
+            this.fixture = new NpmRunnerFixture();
+        }
 
-		[Fact]
-		public void No_Install_Settings_Should_Use_Correct_Argument_Provided_In_NpmInstallSettings() {
-			this.fixture.InstallSettings = null;
+        [Fact]
+        public void No_Install_Settings_Should_Use_Correct_Argument_Provided_In_NpmInstallSettings()
+        {
+            this.fixture.InstallSettings = null;
 
-			var result = this.fixture.Run();
+            var result = this.fixture.Run();
 
-			result.Args.ShouldBe("install");
-		}
+            result.Args.ShouldBe("install");
+        }
 
-		[Fact]
-		public void Globally_Settings_Specified_Should_Use_Correct_Arguments() {
-			this.fixture.InstallSettings = s => s.Globally();
-			var result = this.fixture.Run();
+        [Fact]
+        public void Globally_Settings_Specified_Should_Use_Correct_Arguments()
+        {
+            this.fixture.InstallSettings = s => s.Globally();
+            var result = this.fixture.Run();
 
-			result.Args.ShouldBe("install --global");
-		}
+            result.Args.ShouldBe("install --global");
+        }
 
-		[Fact]
-		public void ForProduction_Settings_Specified_Should_Use_Correct_Arguments() {
-			this.fixture.InstallSettings = s => s.Package("abc").ForProduction();
+        [Fact]
+        public void NoProxy_Settings_Specified_Should_Use_Correct_Arguments()
+        {
+            this.fixture.InstallSettings = s => s.NoProxy();
+            var result = this.fixture.Run();
 
-			Action run = () => this.fixture.Run();
+            result.Args.ShouldBe("install --no-proxy");
+        }
 
-			run.ShouldThrow<ArgumentException>();
-		}
+        [Fact]
+        public void ForProduction_Settings_Specified_Should_Use_Correct_Arguments()
+        {
+            this.fixture.InstallSettings = s => s.Package("abc").ForProduction();
+
+            Action run = () => this.fixture.Run();
+
+            run.ShouldThrow<ArgumentException>();
+        }
 
         [Fact]
         public void ForProduction_Settings_Specified_Should_Use_Correct_Arguments_With_UrlPackage()
@@ -50,62 +64,68 @@ namespace Cake.Npm.Tests {
         }
 
         [Fact]
-		public void Packages_And_ForProduction_Settings_Specified_Should_Use_Throw_ArgumentException() {
-			this.fixture.InstallSettings = s => s.ForProduction();
+        public void Packages_And_ForProduction_Settings_Specified_Should_Use_Throw_ArgumentException()
+        {
+            this.fixture.InstallSettings = s => s.ForProduction();
 
-			var result = this.fixture.Run();
+            var result = this.fixture.Run();
 
-			result.Args.ShouldBe("install --production");
-		}
+            result.Args.ShouldBe("install --production");
+        }
 
-		[Theory]
-		[InlineData("any package")]
-		[InlineData("https://path.co/package/v0.1")]
-		public void Package_Settings_Specified_Should_Use_Correct_Arguments(string package) {
-			this.fixture.InstallSettings = s => s.Package(package);
+        [Theory]
+        [InlineData("any package")]
+        [InlineData("https://path.co/package/v0.1")]
+        public void Package_Settings_Specified_Should_Use_Correct_Arguments(string package)
+        {
+            this.fixture.InstallSettings = s => s.Package(package);
 
-			var result = this.fixture.Run();
+            var result = this.fixture.Run();
 
-			result.Args.ShouldBe("install " + package);
-		}
+            result.Args.ShouldBe("install " + package);
+        }
 
-		[Fact]
-		public void Package_With_Tag_Settings_Specified_Should_Use_Correct_Arguments() {
-			this.fixture.InstallSettings = s => s.Package("any package", ">1.0 && <1.5");
+        [Fact]
+        public void Package_With_Tag_Settings_Specified_Should_Use_Correct_Arguments()
+        {
+            this.fixture.InstallSettings = s => s.Package("any package", ">1.0 && <1.5");
 
-			var result = this.fixture.Run();
+            var result = this.fixture.Run();
 
-			result.Args.ShouldBe("install any package@\">1.0 && <1.5\"");
-		}
+            result.Args.ShouldBe("install any package@\">1.0 && <1.5\"");
+        }
 
-		[Fact]
-		public void Package_With_Tag_And_Scope_Settings_Specified_Should_Use_Correct_Arguments() {
-			this.fixture.InstallSettings = s => s.Package("any package", ">1.0 && <1.5", "@scope");
+        [Fact]
+        public void Package_With_Tag_And_Scope_Settings_Specified_Should_Use_Correct_Arguments()
+        {
+            this.fixture.InstallSettings = s => s.Package("any package", ">1.0 && <1.5", "@scope");
 
-			var result = this.fixture.Run();
+            var result = this.fixture.Run();
 
-			result.Args.ShouldBe("install @scope/any package@\">1.0 && <1.5\"");
-		}
+            result.Args.ShouldBe("install @scope/any package@\">1.0 && <1.5\"");
+        }
 
-		[Fact]
-		public void Package_With_Tag_And_Invalid_Scope_Settings_Specified_Should_Throw_ArgumentException() {
-			this.fixture.InstallSettings = s => s.Package("any package", ">1.0 && <1.5", "scope");
+        [Fact]
+        public void Package_With_Tag_And_Invalid_Scope_Settings_Specified_Should_Throw_ArgumentException()
+        {
+            this.fixture.InstallSettings = s => s.Package("any package", ">1.0 && <1.5", "scope");
 
-			Action run = () => this.fixture.Run();
+            Action run = () => this.fixture.Run();
 
-			run.ShouldThrow<ArgumentException>();
-		}
+            run.ShouldThrow<ArgumentException>();
+        }
 
-		[Theory]
-		[InlineData("any package")]
-		[InlineData("https://path.co/package/v0.1")]
-		public void Package_And_Globally_Settings_Specified_Should_Use_Correct_Arguments(string package) {
-			this.fixture.InstallSettings = s => s.Package(package).Globally();
+        [Theory]
+        [InlineData("any package")]
+        [InlineData("https://path.co/package/v0.1")]
+        public void Package_And_Globally_Settings_Specified_Should_Use_Correct_Arguments(string package)
+        {
+            this.fixture.InstallSettings = s => s.Package(package).Globally();
 
-			var result = this.fixture.Run();
+            var result = this.fixture.Run();
 
-			result.Args.ShouldBe("install " + package + " --global");
-		}
+            result.Args.ShouldBe("install " + package + " --global");
+        }
 
         [Theory]
         [InlineData(NpmLogLevel.Info, "--loglevel info")]

--- a/src/Cake.Npm/NpmInstallSettings.cs
+++ b/src/Cake.Npm/NpmInstallSettings.cs
@@ -1,8 +1,8 @@
+using Cake.Core;
+using Cake.Core.IO;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Cake.Core;
-using Cake.Core.IO;
 
 namespace Cake.Npm
 {
@@ -33,6 +33,7 @@ namespace Cake.Npm
 
             if (Global) args.Append("--global");
             if (Production) args.Append("--production");
+            if (DisableNpmProxy) args.Append("--no-proxy");
         }
 
         /// <summary>
@@ -42,7 +43,7 @@ namespace Cake.Npm
         /// <returns></returns>
         public NpmInstallSettings Package(Uri url)
         {
-            if(!url.IsAbsoluteUri) throw new UriFormatException("must be to an absolute url to package");
+            if (!url.IsAbsoluteUri) throw new UriFormatException("must be to an absolute url to package");
             _packages.Clear();
             _packages.Add(url.AbsoluteUri);
             return this;
@@ -70,7 +71,7 @@ namespace Cake.Npm
                 if (!scope.StartsWith("@")) throw new ArgumentException("scope should start with @");
                 packageName = !string.IsNullOrWhiteSpace(scope) ? $"{scope}/{packageName}" : packageName;
             }
-            
+
             _packages.Add(packageName);
             return this;
         }
@@ -85,7 +86,7 @@ namespace Cake.Npm
             Global = enabled;
             return this;
         }
-        
+
         /// <summary>
         /// Applies the --production parameter (can not be set when installing individual packages
         /// </summary>
@@ -93,10 +94,22 @@ namespace Cake.Npm
         /// <returns></returns>
         public NpmInstallSettings ForProduction(bool enabled = true)
         {
-            if(_packages.Any()) throw new ArgumentException("cant specify production flag when installing individual packages");
+            if (_packages.Any()) throw new ArgumentException("cant specify production flag when installing individual packages");
             Production = enabled;
             return this;
         }
+
+        /// <summary>
+        /// Applies the --no-proxy parameter
+        /// </summary>
+        /// <param name="enabled"></param>
+        /// <returns></returns>
+        public NpmInstallSettings NoProxy(bool enabled = true)
+        {
+            DisableNpmProxy = enabled;
+            return this;
+        }
+
 
         /// <summary>
         /// List of packages to install
@@ -110,6 +123,10 @@ namespace Cake.Npm
         /// --production
         /// </summary>
         public bool Production { get; internal set; }
+        /// <summary>
+        /// --no-proxy
+        /// </summary>
+        public bool DisableNpmProxy { get; internal set; }
 
     }
 }


### PR DESCRIPTION
Useful addition to add the `--no-proxy` flag to an `npm install`. We have proxy issue where this is the only workaround for us.