### PR TITLE
Add ability to pass arbitrary args to npm

### DIFF
--- a/src/Cake.Npm/NpmSettings.cs
+++ b/src/Cake.Npm/NpmSettings.cs
@@ -1,4 +1,7 @@
-﻿namespace Cake.Npm
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Cake.Npm
 {
     using Core;
     using Core.Diagnostics;
@@ -10,6 +13,8 @@
     /// </summary>
     public abstract class NpmSettings: ToolSettings
     {
+        private readonly List<string> _npmArguments = new List<string>();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="NpmSettings"/> class.
         /// </summary>
@@ -28,6 +33,17 @@
         /// Gets or sets the Log level set by Cake.
         /// </summary>
         internal Verbosity? CakeVerbosityLevel { get; set; }
+
+        /// <summary>
+        /// Arguments to pass to npm.
+        /// </summary>
+        public IList<string> NpmArguments
+        {
+            get
+            {
+                return _npmArguments;
+            }
+        }
 
         /// <summary>
         /// Gets the command which should be run.
@@ -52,6 +68,10 @@
         private void AppendNpmSettings(ProcessArgumentBuilder args)
         {
             AppendLogLevel(args, LogLevel);
+            foreach (var arg in NpmArguments)
+            {
+                args.Append(arg);
+            }
         }
 
         /// <summary>

--- a/src/Cake.Npm/NpmSettingsExtensions.cs
+++ b/src/Cake.Npm/NpmSettingsExtensions.cs
@@ -48,5 +48,28 @@
 
             return settings;
         }
+
+        /// <summary>
+        /// Sets the arguments which should be passed to npm.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="arguments">Arguments which should be passed to the script.</param>
+        /// <returns>The <paramref name="settings"/> instance with <see cref="NpmSettings.NpmArguments"/> set to <paramref name="arguments"/>.</returns>
+        public static NpmSettings WithNpmArguments(this NpmSettings settings, string arguments)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            if (string.IsNullOrWhiteSpace(arguments))
+            {
+                throw new ArgumentNullException(nameof(arguments));
+            }
+
+            settings.NpmArguments.Add(arguments);
+
+            return settings;
+        }
     }
 }

--- a/tests/Cake.Npm.Tests/Cake.Npm.Tests.csproj
+++ b/tests/Cake.Npm.Tests/Cake.Npm.Tests.csproj
@@ -26,5 +26,9 @@
   <ItemGroup>
     <Compile Include="..\..\VersionAssemblyInfo.cs" Link="VersionAssemblyInfo.cs" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   
 </Project>

--- a/tests/Cake.Npm.Tests/Install/NpmInstallerSettingsExtensionsTests.cs
+++ b/tests/Cake.Npm.Tests/Install/NpmInstallerSettingsExtensionsTests.cs
@@ -729,5 +729,60 @@
                 settings.Packages.ShouldContain(scope + "/" + packageName + "@\"" + tag + "\"");
             }
         }
+
+        public sealed class TheWithNpmArgumentsMethod
+        {
+            [Fact]
+            public void Should_Add_Argument()
+            {
+                // Given
+                NpmInstallSettings settings = new NpmInstallSettings();
+
+                // When
+                settings.WithNpmArguments("--no-color");
+
+                // Then
+                settings.NpmArguments.ShouldContain("--no-color");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                NpmInstallSettings settings = null;
+
+                // When
+                var result = Record.Exception(() => settings.WithNpmArguments("--no-color"));
+
+                // Then
+                result.IsArgumentNullException("settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Args_Are_Null()
+            {
+                // Given
+                NpmInstallSettings settings = new NpmInstallSettings();
+
+                // When
+                var result = Record.Exception(() => settings.WithNpmArguments(null));
+
+                // Then
+                result.IsArgumentNullException("arguments");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Args_Are_Whitespace()
+            {
+                // Given
+                NpmInstallSettings settings = new NpmInstallSettings();
+
+                // When
+                var result = Record.Exception(() => settings.WithNpmArguments(" "));
+
+                // Then
+                result.IsArgumentNullException("arguments");
+            }
+        }
     }
 }

--- a/tests/Cake.Npm.Tests/Install/NpmInstallerTests.cs
+++ b/tests/Cake.Npm.Tests/Install/NpmInstallerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Cake.Core.Diagnostics;
 using Xunit;
 using Cake.Npm.Install;
@@ -245,6 +246,29 @@ namespace Cake.Npm.Tests.Install
                 var fixture = new NpmInstallerFixture();
                 fixture.Settings.CakeVerbosityLevel = verbosity;
 
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal(expected, result.Args);
+            }
+
+
+            [Theory]
+            [InlineData(new [] {"--an-arg"}, "install --an-arg")]
+            [InlineData(new string[] {}, "install")]
+            [InlineData(new[] { "--no-color", "--an-arg" }, "install --no-color --an-arg")]
+            [InlineData(new[] { "--no-color --an-arg" }, "install --no-color --an-arg")]
+            public void Should_Pass_In_Arbitrary_Npm_Arguments(string[] npmArgs, string expected)
+            {
+                // Given
+                var fixture = new NpmInstallerFixture();
+
+                foreach (var npmArg in npmArgs)
+                {
+                    fixture.Settings.WithNpmArguments(npmArg);
+                }
+                
                 // When
                 var result = fixture.Run();
 


### PR DESCRIPTION
Needed to add the `no-color` argument to npm for our build tools, figured it would be handy to pass arbitrary npm arguments as is done for scripts:

https://github.com/timjk/Cake.Npm/blob/34542352f5a07586a1b6345ebb1240956f6e59d0/src/Cake.Npm/RunScript/NpmRunScriptSettingsExtensions.cs#L16

