### PR TITLE
Add the ability to specify --no-optional in NpmInstallSettings

### DIFF
--- a/src/Cake.Npm/Install/NpmInstallSettings.cs
+++ b/src/Cake.Npm/Install/NpmInstallSettings.cs
@@ -38,6 +38,12 @@
         public bool Production { get; set; }
 
         /// <summary>
+        /// Gets a value indicating whether npm should prevent optional dependencies from being installed
+        /// (the --no-optional argument)
+        /// </summary>
+        public bool NoOptional { get; set; }
+
+        /// <summary>
         /// Gets the list of packages which should be installed.
         /// </summary>
         public IList<string> Packages => _packages;
@@ -63,6 +69,11 @@
             if (Global)
             {
                 args.Append("--global");
+            }
+
+            if (NoOptional)
+            {
+                args.Append("--no-optional");
             }
 
             if (Production)

--- a/src/Cake.Npm/Install/NpmInstallSettingsExtensions.cs
+++ b/src/Cake.Npm/Install/NpmInstallSettingsExtensions.cs
@@ -9,7 +9,7 @@
     public static class NpmInstallSettingsExtensions
     {
         /// <summary>
-        /// Defines tht npm should fetch remote resources even if a local copy
+        /// Defines that npm should fetch remote resources even if a local copy
         /// exists on disk.
         /// </summary>
         /// <param name="settings">The settings.</param>
@@ -25,7 +25,7 @@
         }
 
         /// <summary>
-        /// Defines tht npm should not fetch remote resources if a local copy exists on disk.
+        /// Defines that npm should not fetch remote resources if a local copy exists on disk.
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <returns>The <paramref name="settings"/> instance with <see cref="NpmInstallSettings.Force"/> set to <c>false</c>.</returns>
@@ -106,11 +106,11 @@
         }
 
         /// <summary>
-        /// Defines that npm should npm should prevent optional dependencies from being installed
+        /// Defines that npm should prevent optional dependencies from being installed
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <returns>The <paramref name="settings"/> instance with <see cref="NpmInstallSettings.NoOptional"/> set to <c>true</c>.</returns>
-        public static NpmInstallSettings WithNoOptional(this NpmInstallSettings settings)
+        public static NpmInstallSettings WithoutOptionalDependencies(this NpmInstallSettings settings)
         {
             if (settings == null)
             {
@@ -121,11 +121,11 @@
         }
 
         /// <summary>
-        /// Defines that npm should not prevent optional dependencies from being installed
+        /// Defines that npm should install optional dependencies
         /// </summary>
         /// <param name="settings">The settings.</param>
         /// <returns>The <paramref name="settings"/> instance with <see cref="NpmInstallSettings.NoOptional"/> set to <c>false</c>.</returns>
-        public static NpmInstallSettings WithoutNoOptional(this NpmInstallSettings settings)
+        public static NpmInstallSettings WithOptionalDependencies(this NpmInstallSettings settings)
         {
             if (settings == null)
             {

--- a/src/Cake.Npm/Install/NpmInstallSettingsExtensions.cs
+++ b/src/Cake.Npm/Install/NpmInstallSettingsExtensions.cs
@@ -106,6 +106,53 @@
         }
 
         /// <summary>
+        /// Defines that npm should npm should prevent optional dependencies from being installed
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The <paramref name="settings"/> instance with <see cref="NpmInstallSettings.NoOptional"/> set to <c>true</c>.</returns>
+        public static NpmInstallSettings WithNoOptional(this NpmInstallSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            return settings.WithNoOptional(true);
+        }
+
+        /// <summary>
+        /// Defines that npm should not prevent optional dependencies from being installed
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The <paramref name="settings"/> instance with <see cref="NpmInstallSettings.NoOptional"/> set to <c>false</c>.</returns>
+        public static NpmInstallSettings WithoutNoOptional(this NpmInstallSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            return settings.WithNoOptional(false);
+        }
+
+        /// <summary>
+        /// Defines whether npm should prevent optional dependencies from being installed
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="value">Value which should be set.</param>
+        /// <returns>The <paramref name="settings"/> instance with <see cref="NpmInstallSettings.NoOptional"/> set to <paramref name="value"/>.</returns>
+        public static NpmInstallSettings WithNoOptional(this NpmInstallSettings settings, bool value)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.NoOptional = value;
+            return settings;
+        }
+
+        /// <summary>
         /// Install a package from a specific url.
         /// </summary>
         /// <param name="settings">The settings.</param>

--- a/tests/Cake.Npm.Tests/Install/NpmInstallerSettingsExtensionsTests.cs
+++ b/tests/Cake.Npm.Tests/Install/NpmInstallerSettingsExtensionsTests.cs
@@ -63,7 +63,7 @@
             }
         }
 
-        public sealed class TheWithNoOptionalMethod
+        public sealed class TheWithoutOptionalDependenciesMethod
         {
             [Fact]
             public void Should_Throw_If_Settings_Are_Null()
@@ -72,7 +72,7 @@
                 NpmInstallSettings settings = null;
 
                 // When
-                var result = Record.Exception(() => settings.WithNoOptional());
+                var result = Record.Exception(() => settings.WithoutOptionalDependencies());
 
                 // Then
                 result.IsArgumentNullException("settings");
@@ -84,14 +84,14 @@
                 var settings = new NpmInstallSettings();
 
                 // When
-                settings.WithNoOptional();
+                settings.WithoutOptionalDependencies();
 
                 // Then
                 settings.NoOptional.ShouldBe(true);
             }
         }
 
-        public sealed class TheWithoutNoOptionalMethod
+        public sealed class TheWithOptionalDependenciesMethod
         {
             [Fact]
             public void Should_Throw_If_Settings_Are_Null()
@@ -100,7 +100,7 @@
                 NpmInstallSettings settings = null;
 
                 // When
-                var result = Record.Exception(() => settings.WithoutNoOptional());
+                var result = Record.Exception(() => settings.WithOptionalDependencies());
 
                 // Then
                 result.IsArgumentNullException("settings");
@@ -112,7 +112,7 @@
                 var settings = new NpmInstallSettings();
 
                 // When
-                settings.WithoutNoOptional();
+                settings.WithOptionalDependencies();
 
                 // Then
                 settings.NoOptional.ShouldBe(false);

--- a/tests/Cake.Npm.Tests/Install/NpmInstallerSettingsExtensionsTests.cs
+++ b/tests/Cake.Npm.Tests/Install/NpmInstallerSettingsExtensionsTests.cs
@@ -63,6 +63,62 @@
             }
         }
 
+        public sealed class TheWithNoOptionalMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                NpmInstallSettings settings = null;
+
+                // When
+                var result = Record.Exception(() => settings.WithNoOptional());
+
+                // Then
+                result.IsArgumentNullException("settings");
+            }
+            [Fact]
+            public void Should_Set_NoOptional()
+            {
+                // Given
+                var settings = new NpmInstallSettings();
+
+                // When
+                settings.WithNoOptional();
+
+                // Then
+                settings.NoOptional.ShouldBe(true);
+            }
+        }
+
+        public sealed class TheWithoutNoOptionalMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                NpmInstallSettings settings = null;
+
+                // When
+                var result = Record.Exception(() => settings.WithoutNoOptional());
+
+                // Then
+                result.IsArgumentNullException("settings");
+            }
+            [Fact]
+            public void Should_Set_NoOptional()
+            {
+                // Given
+                var settings = new NpmInstallSettings();
+
+                // When
+                settings.WithoutNoOptional();
+
+                // Then
+                settings.NoOptional.ShouldBe(false);
+            }
+        }
+
         public sealed class TheInstallGloballyMethod
         {
             [Fact]

--- a/tests/Cake.Npm.Tests/Install/NpmInstallerTests.cs
+++ b/tests/Cake.Npm.Tests/Install/NpmInstallerTests.cs
@@ -165,6 +165,20 @@ namespace Cake.Npm.Tests.Install
             }
 
             [Fact]
+            public void Should_Add_NoOptional_To_Arguments_If_Specified()
+            {
+                // Given
+                var fixture = new NpmInstallerFixture();
+                fixture.Settings.NoOptional = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("install --no-optional", result.Args);
+            }
+
+            [Fact]
             public void Should_Add_Global_To_Arguments_If_Not_Null()
             {
                 // Given


### PR DESCRIPTION
The --no-optional flag can now be specified in NpmInstallSettings. Useful to work around https://github.com/npm/npm/issues/17671

Fixes #54