### PR TITLE
expose option to redirect stderr/out to NpmSettings

### DIFF
--- a/src/Cake.Npm/NpmSettings.cs
+++ b/src/Cake.Npm/NpmSettings.cs
@@ -17,12 +17,24 @@
         protected NpmSettings(string command)
         {
             Command = command;
+            RedirectStandardError = false;
+            RedirectStandardOutput = false;
         }
 
         /// <summary>
         /// Gets or sets the log level which should be used to run the npm command.
         /// </summary>
         public NpmLogLevel LogLevel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the process option to redirect standard error
+        /// </summary>
+        public bool RedirectStandardError { get; set; }
+
+        /// <summary>
+        /// Gets or sets the process option to redirect standard output
+        /// </summary>
+        public bool RedirectStandardOutput { get; set; }
 
         /// <summary>
         /// Gets or sets the Log level set by Cake.

--- a/src/Cake.Npm/NpmTool.cs
+++ b/src/Cake.Npm/NpmTool.cs
@@ -69,7 +69,7 @@
         /// <param name="settings">The settings.</param>
         protected void RunCore(TSettings settings)
         {
-            RunCore(settings, null, null);
+            RunCore(settings, new ProcessSettings(), null);
         }
 
         /// <summary>
@@ -89,6 +89,9 @@
             {
                 settings.CakeVerbosityLevel = CakeLog.Verbosity;
             }
+
+            processSettings.RedirectStandardError = settings.RedirectStandardError;
+            processSettings.RedirectStandardOutput = settings.RedirectStandardOutput;
 
             var args = GetArguments(settings);
             Run(settings, args, processSettings, postAction);

--- a/tests/Cake.Npm.Tests/Install/NpmInstallerTests.cs
+++ b/tests/Cake.Npm.Tests/Install/NpmInstallerTests.cs
@@ -10,6 +10,17 @@ namespace Cake.Npm.Tests.Install
         public sealed class TheInstallMethod
         {
             [Fact]
+            public void Should_Redirect_Standard_Error()
+            {
+                var fixture = new NpmInstallerFixture();
+                fixture.Settings.RedirectStandardError = true;
+
+                var result = fixture.Run();
+
+                Assert.True(result.Process.RedirectStandardError);
+            }
+
+            [Fact]
             public void Should_Throw_If_Settings_Are_Null()
             {
                 // Given

--- a/tests/Cake.Npm.Tests/Pack/NpmPackerTests.cs
+++ b/tests/Cake.Npm.Tests/Pack/NpmPackerTests.cs
@@ -8,6 +8,17 @@
         public sealed class ThePackMethod
         {
             [Fact]
+            public void Should_Redirect_Standard_Error()
+            {
+                var fixture = new NpmPackerFixture();
+                fixture.Settings.RedirectStandardError = true;
+
+                var result = fixture.Run();
+
+                Assert.True(result.Process.RedirectStandardError);
+            }
+
+            [Fact]
             public void Should_Throw_If_Settings_Are_Null()
             {
                 // Given

--- a/tests/Cake.Npm.Tests/Publish/NpmPublisherTests.cs
+++ b/tests/Cake.Npm.Tests/Publish/NpmPublisherTests.cs
@@ -10,6 +10,17 @@
         public sealed class ThePublishMethod
         {
             [Fact]
+            public void Should_Redirect_Standard_Error()
+            {
+                var fixture = new NpmPublisherFixture();
+                fixture.Settings.RedirectStandardError = true;
+
+                var result = fixture.Run();
+
+                Assert.True(result.Process.RedirectStandardError);
+            }
+
+            [Fact]
             public void Should_Throw_If_Settings_Are_Null()
             {
                 // Given

--- a/tests/Cake.Npm.Tests/Rebuild/NpmRebuilderTests.cs
+++ b/tests/Cake.Npm.Tests/Rebuild/NpmRebuilderTests.cs
@@ -10,6 +10,17 @@
         public sealed class TheRebuildMethod
         {
             [Fact]
+            public void Should_Redirect_Standard_Error()
+            {
+                var fixture = new NpmRebuilderFixture();
+                fixture.Settings.RedirectStandardError = true;
+
+                var result = fixture.Run();
+
+                Assert.True(result.Process.RedirectStandardError);
+            }
+
+            [Fact]
             public void Should_Throw_If_Settings_Are_Null()
             {
                 // Given

--- a/tests/Cake.Npm.Tests/RunScript/NpmScriptRunnerTests.cs
+++ b/tests/Cake.Npm.Tests/RunScript/NpmScriptRunnerTests.cs
@@ -8,6 +8,18 @@
         public sealed class TheRunScriptMethod
         {
             [Fact]
+            public void Should_Redirect_Standard_Error()
+            {
+                var fixture = new NpmRunScriptFixture();
+                fixture.Settings.RedirectStandardError = true;
+                fixture.Settings.ScriptName = "foo bar";
+
+                var result = fixture.Run();
+
+                Assert.True(result.Process.RedirectStandardError);
+            }
+
+            [Fact]
             public void Should_Throw_If_Settings_Are_Null()
             {
                 // Given


### PR DESCRIPTION
This option exposes the Cake process runner redirect stdout/stderr flag. This is important because in certain situations (specifically in my case, running through TeamCity on an older version of Windows), NPM's frustrating habit of putting informational messages in stderr causes TeamCity to detect the build as failed.

This PR does not seek to solve the problem of 'what to do with stderr/out after its been redirected'. I assume if you're going to mess with this, you probably know what you're doing...?

Fixes #60 