### PR TITLE
Added 'Registry' to NpmCiSettings

### DIFF
--- a/src/Cake.Npm.Tests/Ci/NpmCiToolTests.cs
+++ b/src/Cake.Npm.Tests/Ci/NpmCiToolTests.cs
@@ -106,6 +106,20 @@ namespace Cake.Npm.Tests.Ci
                 Assert.Equal("ci --production", result.Args);
             }
 
-        }
+
+	        [Fact]
+	        public void Should_Include_Registry_Args_If_Set()
+	        {
+		        // Given
+		        var fixture = new NpmCiToolFixture();
+		        fixture.Settings.Registry = "https://www.myget.org/feed";
+
+		        // When
+		        var result = fixture.Run();
+
+		        // Then
+		        Assert.Equal("ci --registry=https://www.myget.org/feed", result.Args);
+	        }
+		}
     }
 }

--- a/src/Cake.Npm/Ci/NpmCiSettings.cs
+++ b/src/Cake.Npm/Ci/NpmCiSettings.cs
@@ -21,7 +21,12 @@ namespace Cake.Npm.Ci
         /// </summary>
         public bool Production { get; set; }
 
-        /// <inheritdoc />
+		/// <summary>
+		/// Sets the registry param for npm
+		/// </summary>
+	    public string Registry { get; set; }
+
+	    /// <inheritdoc />
         protected override void EvaluateCore(ProcessArgumentBuilder args)
         {
             base.EvaluateCore(args);
@@ -30,6 +35,11 @@ namespace Cake.Npm.Ci
             {
                 args.Append("--production");
             }
+
+	        if (!string.IsNullOrWhiteSpace(Registry))
+	        {
+		        args.Append($"--registry={Registry}");
+	        }
         }
     }
 }


### PR DESCRIPTION
Needed to run 'npm ci' with private npm repos, e.g. "npm ci --registry=https://www.myget.org/feed/..."