### PR TITLE
Disable publishing to MyGet

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -10,6 +10,7 @@ BuildParameters.SetParameters(
     repositoryOwner: "cake-contrib",
     repositoryName: "Cake.Npm",
     appVeyorAccountName: "cakecontrib",
+    shouldPublishMyGet: false,
     shouldRunDupFinder: false,
     shouldRunCodecov: false,
     shouldRunGitVersion: true);


### PR DESCRIPTION
Disable publishing of NuGet packages to MyGet, since we run out of quota. Once Cake.Recipe 2.0.0 is available we can enable publishing of CI package to GitHub.