### PR TITLE
(GH-97) Added StandardErrorAction and StandardOutputAction in NpmSettings

### DIFF
--- a/src/Cake.Npm.Tests/NpmSettingsExtensionsTests.cs
+++ b/src/Cake.Npm.Tests/NpmSettingsExtensionsTests.cs
@@ -1,5 +1,7 @@
 ﻿namespace Cake.Npm.Tests
 {
+    using System;
+
     using Cake.Npm.Install;
     using Shouldly;
     using Xunit;
@@ -82,6 +84,34 @@
 
                 // Then
                 settings.WorkingDirectory.ToString().ShouldBe(@"c:/temp");
+            }
+
+            [Fact]
+            public void Should_Set_StandardOutputAction()
+            {
+                // Given
+                var settings = new NpmInstallSettings();
+                Action<string> action = x => { };
+
+                // When
+                settings.SetRedirectedStandardOutputHandler(action);
+
+                // Then
+                settings.StandardOutputAction.ShouldBe(action);
+            }
+
+            [Fact]
+            public void Should_Set_StandardErrorAction()
+            {
+                // Given
+                var settings = new NpmInstallSettings();
+                Action<string> action = x => { };
+
+                // When
+                settings.SetRedirectedStandardErrorHandler(action);
+
+                // Then
+                settings.StandardErrorAction.ShouldBe(action);
             }
         }
     }

--- a/src/Cake.Npm/NpmSettings.cs
+++ b/src/Cake.Npm/NpmSettings.cs
@@ -1,5 +1,7 @@
 ﻿namespace Cake.Npm
 {
+    using System;
+
     using Core;
     using Core.Diagnostics;
     using Core.IO;
@@ -27,14 +29,38 @@
         public NpmLogLevel LogLevel { get; set; }
 
         /// <summary>
-        /// Gets or sets the process option to redirect standard error
+        /// Gets or sets the process option to redirect standard error output.
         /// </summary>
+        /// <remarks>
+        /// To retrieve and process the standard error output 
+        /// <see cref="StandardErrorAction"/> needs to be set.
+        /// </remarks>
         public bool RedirectStandardError { get; set; }
 
         /// <summary>
-        /// Gets or sets the process option to redirect standard output
+        /// Gets or sets an action to retrieve and process standard error output.
         /// </summary>
+        /// <remarks>
+        /// Setting a standard error action implicitely set <see cref="RedirectStandardError"/>.
+        /// </remarks>
+        public Action<string> StandardErrorAction { get; set; }
+
+        /// <summary>
+        /// Gets or sets the process option to redirect standard output.
+        /// </summary>
+        /// <remarks>
+        /// To retrieve and process the standard error output 
+        /// <see cref="StandardOutputAction"/> needs to be set.
+        /// </remarks>
         public bool RedirectStandardOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets an action to retrieve and process standard output.
+        /// </summary>
+        /// <remarks>
+        /// Setting a standard error action implicitely set <see cref="RedirectStandardOutput"/>.
+        /// </remarks>
+        public Action<string> StandardOutputAction { get; set; }
 
         /// <summary>
         /// Gets or sets the Log level set by Cake.

--- a/src/Cake.Npm/NpmSettingsExtensions.cs
+++ b/src/Cake.Npm/NpmSettingsExtensions.cs
@@ -48,5 +48,51 @@
 
             return settings;
         }
+
+        /// <summary>
+        /// Sets the StandardError-Action
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="standardErrorAction">The StandardError-Action.</param>
+        /// <returns>The <paramref name="settings"/> instance with <see cref="NpmSettings.StandardErrorAction"/> set to <paramref name="standardErrorAction"/>.</returns>
+        public static NpmSettings SetRedirectedStandardErrorHandler(this NpmSettings settings, Action<string> standardErrorAction)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            if (standardErrorAction == null)
+            {
+                throw new ArgumentNullException(nameof(standardErrorAction));
+            }
+
+            settings.StandardErrorAction = standardErrorAction;
+
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the StandardOutput-Action
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="standardOutputAction">The StandardOutput-Action.</param>
+        /// <returns>The <paramref name="settings"/> instance with <see cref="NpmSettings.StandardOutputAction"/> set to <paramref name="standardOutputAction"/>.</returns>
+        public static NpmSettings SetRedirectedStandardOutputHandler(this NpmSettings settings, Action<string> standardOutputAction)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            if (standardOutputAction == null)
+            {
+                throw new ArgumentNullException(nameof(standardOutputAction));
+            }
+
+            settings.StandardOutputAction = standardOutputAction;
+
+            return settings;
+        }
     }
 }

--- a/src/Cake.Npm/NpmTool.cs
+++ b/src/Cake.Npm/NpmTool.cs
@@ -90,8 +90,31 @@
                 settings.CakeVerbosityLevel = CakeLog.Verbosity;
             }
 
-            processSettings.RedirectStandardError = settings.RedirectStandardError;
-            processSettings.RedirectStandardOutput = settings.RedirectStandardOutput;
+            processSettings.RedirectStandardOutput =
+                settings.RedirectStandardOutput ||
+                settings.StandardOutputAction != null;
+
+            if (settings.StandardOutputAction != null)
+            {
+                processSettings.RedirectedStandardOutputHandler = x =>
+                {
+                    settings.StandardOutputAction(x);
+                    return x;
+                };
+            }
+
+            processSettings.RedirectStandardError =
+                settings.RedirectStandardError ||
+                settings.StandardErrorAction != null;
+
+            if (settings.StandardErrorAction != null)
+            {
+                processSettings.RedirectedStandardErrorHandler = x =>
+                {
+                    settings.StandardErrorAction(x);
+                    return x;
+                };
+            }
 
             var args = GetArguments(settings);
             Run(settings, args, processSettings, postAction);


### PR DESCRIPTION
* Added the actions in `NpmSettings`
* Added corresponding extensions and unit-tests
* Implemented using the `RedirectedStandard[Output|Error]Handler ` on processSettings

Should fix #97 