### PR TITLE
(GH-96) Added aliases NpmBumpVersion and NpmViewVersion

### DIFF
--- a/src/Cake.Npm.Tests/BumpVersion/NpmBumpVersionToolFixture.cs
+++ b/src/Cake.Npm.Tests/BumpVersion/NpmBumpVersionToolFixture.cs
@@ -1,0 +1,14 @@
+﻿
+namespace Cake.Npm.Tests.BumpVersion
+{
+    using Cake.Npm.BumpVersion;
+
+    internal sealed class NpmBumpVersionToolFixture : NpmFixture<NpmBumpVersionSettings>
+    {
+        protected override void RunTool()
+        {
+            var tool = new NpmBumpVersionTool(FileSystem, Environment, ProcessRunner, Tools, Log);
+            tool.BumpVersion(Settings);
+        }
+    }
+}

--- a/src/Cake.Npm.Tests/BumpVersion/NpmBumpVersionToolTests.cs
+++ b/src/Cake.Npm.Tests/BumpVersion/NpmBumpVersionToolTests.cs
@@ -1,0 +1,155 @@
+﻿namespace Cake.Npm.Tests.BumpVersion
+{
+    using Npm.BumpVersion;
+
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    using Xunit;
+
+    public class NpmBumpVersionToolTests
+    {
+        public sealed class TheBumpVersionMethod
+        {
+            private NpmBumpVersionToolFixture fixture;
+
+            public TheBumpVersionMethod()
+            {
+                fixture = new NpmBumpVersionToolFixture();
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                result.IsArgumentNullException("settings");
+            }
+
+            [Theory]
+            [ClassData(typeof(ExtensionNullCheckData))]
+            public void Should_Throw_If_Settings_Are_Null_For_All_Extensions(Action<NpmBumpVersionSettings> extensionAction)
+            {
+                // Given
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => extensionAction(fixture.Settings));
+
+                // Then
+                result.IsArgumentNullException("settings");
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_And_Default_Arguments()
+            {
+                // Given
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("version minor", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Version_Argument()
+            {
+                // Given
+                fixture.Settings.Version = "1.2.3";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("version 1.2.3", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Version_Argument_Using_Extensions()
+            {
+                // Given
+                fixture.Settings.WithVersion("1.2.3");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("version 1.2.3", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Force_Switch()
+            {
+                // Given
+                fixture.Settings.Force = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("version minor -f", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Force_Switch_Using_Extension()
+            {
+                // Given
+                fixture.Settings.WithForce();
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("version minor -f", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_CommitMessage_Option()
+            {
+                // Given
+                fixture.Settings.CommitMessage = "Bumped minor version.";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("version minor -m \"Bumped minor version.\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_CommitMessage_Option_Using_Extension()
+            {
+                // Given
+                fixture.Settings.WithCommitMessage("Bumped minor version.");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("version minor -m \"Bumped minor version.\"", result.Args);
+            }
+
+            class ExtensionNullCheckData : IEnumerable<object[]>
+            {
+                public IEnumerator<object[]> GetEnumerator()
+                {
+                    yield return new object[] { (Action<NpmBumpVersionSettings>)(x => x.WithForce()) };
+                    yield return new object[] { (Action<NpmBumpVersionSettings>)(x => x.WithCommitMessage("")) };
+                    yield return new object[] { (Action<NpmBumpVersionSettings>)(x => x.WithVersion("")) };
+                }
+
+                IEnumerator IEnumerable.GetEnumerator()
+                {
+                    return GetEnumerator();
+                }
+            }
+        }
+    }
+}

--- a/src/Cake.Npm.Tests/ExceptionAssertExtensions.cs
+++ b/src/Cake.Npm.Tests/ExceptionAssertExtensions.cs
@@ -21,5 +21,11 @@
         {
             Assert.IsType<UriFormatException>(exception);
         }
+
+        public static void IsArgumentOutOfRangeException(this Exception exception, string parameterName)
+        {
+            Assert.IsType<ArgumentOutOfRangeException>(exception);
+            Assert.Equal(parameterName, ((ArgumentOutOfRangeException)exception).ParamName);
+        }
     }
 }

--- a/src/Cake.Npm.Tests/ViewVersion/NpmViewVersionToolFixture.cs
+++ b/src/Cake.Npm.Tests/ViewVersion/NpmViewVersionToolFixture.cs
@@ -1,0 +1,16 @@
+﻿
+namespace Cake.Npm.Tests.ViewVersion
+{
+    using Cake.Npm.ViewVersion;
+
+    internal sealed class NpmViewVersionToolFixture : NpmFixture<NpmViewVersionSettings>
+    {
+        internal string Version { get; private set; }
+
+        protected override void RunTool()
+        {
+            var tool = new NpmViewVersionTool(FileSystem, Environment, ProcessRunner, Tools, Log);
+            Version = tool.Version(Settings);
+        }
+    }
+}

--- a/src/Cake.Npm.Tests/ViewVersion/NpmViewVersionToolTests.cs
+++ b/src/Cake.Npm.Tests/ViewVersion/NpmViewVersionToolTests.cs
@@ -1,0 +1,113 @@
+﻿namespace Cake.Npm.Tests.ViewVersion
+{
+    using Cake.Npm.ViewVersion;
+
+    using Shouldly;
+
+    using Xunit;
+
+    public class NpmViewVersionToolTests
+    {
+        public sealed class TheViewVersionMethod
+        {
+            private NpmViewVersionToolFixture fixture;
+
+            public TheViewVersionMethod()
+            {
+                fixture = new NpmViewVersionToolFixture();
+            }
+
+            [Fact]
+            public void Should_Throw_If_Settings_Are_Null()
+            {
+                // Given
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                result.IsArgumentNullException("settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Package_Is_Null()
+            {
+                // Given
+                fixture.Settings.Package = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Run());
+
+                // Then
+                result.IsArgumentOutOfRangeException("Package");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Extension_Is_Called_On_Null()
+            {
+                // Given
+                fixture.Settings = null;
+
+                // When
+                var result = Record.Exception(() => fixture.Settings.ForPackage("cakejs"));
+
+                // Then
+                result.IsArgumentNullException("settings");
+            }
+
+            [Fact]
+            public void Should_Add_Mandatory_And_Default_Arguments()
+            {
+                // Given
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("view npm version", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Package_Argument()
+            {
+                // Given
+                fixture.Settings.Package = "cakejs";
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("view cakejs version", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Package_Argument_Using_Extension()
+            {
+                // Given
+                fixture.Settings.ForPackage("cakejs");
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("view cakejs version", result.Args);
+            }
+
+            [Fact]
+            public void Should_Return_Version_From_StandardOutput()
+            {
+                const string version = "1.1.0";
+
+                // Given
+                fixture.ProcessRunner.Process.SetStandardOutput(new[] { version });
+
+                // When
+                fixture.Run();
+
+                // Then
+                fixture.Version.ShouldBe(version);
+            }
+        }
+    }
+}

--- a/src/Cake.Npm/BumpVersion/NpmBumpVersionSettings.cs
+++ b/src/Cake.Npm/BumpVersion/NpmBumpVersionSettings.cs
@@ -1,0 +1,58 @@
+﻿namespace Cake.Npm.BumpVersion
+{
+    using Core;
+    using Core.IO;
+
+    /// <summary>
+    /// Contains settings used by <see cref="NpmBumpVersionTool"/>.
+    /// </summary>
+    public class NpmBumpVersionSettings : NpmSettings
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NpmBumpVersionSettings"/> class.
+        /// </summary>
+        public NpmBumpVersionSettings()
+            : base("version")
+        {
+            Version = "minor";
+        }
+
+        /// <summary>
+        /// Gets or sets the force-option
+        /// </summary>
+        public bool Force { get; set; }
+
+        /// <summary>
+        /// Gets or sets the commit message.
+        /// </summary>
+        public string CommitMessage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the version to bump to. Should be a valid semver
+        /// or one of <c>"patch"</c>, <c>"minor"</c>, <c>"major"</c>, 
+        /// <c>"prepatch"</c>, <c>"preminor"</c>, <c>"premajor"</c>, 
+        /// <c>"prerelease"</c> or <c>"from-git"</c>.
+        /// </summary>
+        public string Version  {get;set; }
+
+        /// <summary>
+        /// Evaluates the settings and writes them to <paramref name="args"/>.
+        /// </summary>
+        /// <param name="args">The argument builder into which the settings should be written.</param>
+        protected override void EvaluateCore(ProcessArgumentBuilder args)
+        {
+            base.EvaluateCore(args);
+            args.Append(Version);
+
+            if (!string.IsNullOrEmpty(CommitMessage))
+            {
+                args.AppendSwitchQuoted("-m", CommitMessage);
+            }
+
+            if (Force)
+            {
+                args.Append("-f");
+            }
+        }
+    }
+}

--- a/src/Cake.Npm/BumpVersion/NpmBumpVersionSettingsExtensions.cs
+++ b/src/Cake.Npm/BumpVersion/NpmBumpVersionSettingsExtensions.cs
@@ -1,0 +1,61 @@
+﻿namespace Cake.Npm.BumpVersion
+{
+    using System;
+
+    /// <summary>
+    /// Extensions for <see cref="NpmBumpVersionSettings"/>.
+    /// </summary>
+    public static class NpmBumpVersionSettingsExtensions
+    {
+        /// <summary>
+        /// Defines that npm version should commit, even if the repository is not clean.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="force">Whether to set force, or not.</param>
+        /// <returns>The <paramref name="settings"/> instance with <see cref="NpmBumpVersionSettings.Force"/> set.</returns>
+        public static NpmBumpVersionSettings WithForce(this NpmBumpVersionSettings settings, bool force = true)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.Force = force;
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the commit message. 
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="message">The commit message to set.</param>
+        /// <returns>The <paramref name="settings"/> instance with <see cref="NpmBumpVersionSettings.CommitMessage"/> set.</returns>
+        public static NpmBumpVersionSettings WithCommitMessage(this NpmBumpVersionSettings settings, string message)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.CommitMessage = message;
+            return settings;
+        }
+
+        /// <summary>
+        /// Sets the version to bump.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="version">The version to bump.</param>
+        /// <returns>The <paramref name="settings"/> instance with <see cref="NpmBumpVersionSettings.CommitMessage"/> set.</returns>
+        public static NpmBumpVersionSettings WithVersion(this NpmBumpVersionSettings settings, string version)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.Version = version;
+            return settings;
+        }
+    }
+}

--- a/src/Cake.Npm/BumpVersion/NpmBumpVersionTool.cs
+++ b/src/Cake.Npm/BumpVersion/NpmBumpVersionTool.cs
@@ -1,0 +1,47 @@
+﻿namespace Cake.Npm.BumpVersion
+{
+    using System;
+
+    using Core;
+    using Core.Diagnostics;
+    using Core.IO;
+    using Core.Tooling;
+
+    /// <summary>
+    /// Tool for bumping the version.
+    /// </summary>
+    public class NpmBumpVersionTool : NpmTool<NpmBumpVersionSettings>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NpmBumpVersionTool"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        /// <param name="log">Cake log instance.</param>
+        public NpmBumpVersionTool(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools,
+            ICakeLog log) 
+            : base(fileSystem, environment, processRunner, tools, log)
+        {
+        }
+
+        /// <summary>
+        /// Calls npm version to bump a version.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        public void BumpVersion(NpmBumpVersionSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            RunCore(settings);
+        }
+    }
+}

--- a/src/Cake.Npm/Namespaces.cs
+++ b/src/Cake.Npm/Namespaces.cs
@@ -107,3 +107,27 @@ namespace Cake.Npm.Update
     {
     }
 }
+
+// ReSharper disable once CheckNamespace
+namespace Cake.Npm.BumpVersion
+{
+    /// <summary>
+    /// This namespace contain types used for bumping the package version.
+    /// </summary>
+    [CompilerGenerated]
+    internal class NamespaceDoc
+    {
+    }
+}
+
+// ReSharper disable once CheckNamespace
+namespace Cake.Npm.ViewVersion
+{
+    /// <summary>
+    /// This namespace contain types used for viewing the package versions.
+    /// </summary>
+    [CompilerGenerated]
+    internal class NamespaceDoc
+    {
+    }
+}

--- a/src/Cake.Npm/NpmBumpVersionAliases.cs
+++ b/src/Cake.Npm/NpmBumpVersionAliases.cs
@@ -1,63 +1,63 @@
 namespace Cake.Npm
 {
     using System;
-    using Cake.Npm.Version;
+    using BumpVersion;
     using Core;
     using Core.Annotations;
 
     /// <summary>
-    /// Npm Version aliases.
-    /// Use this to get the current npm version in use.
+    /// Npm BumpVersion aliases. 
+    /// Use this if you want to use 'npm version' to bump the version.
+    /// Use this to bump the version of the current package.
     /// For other functions of npm version, see:
     /// <list type="bullet">
     ///   <item><description><see cref="NpmViewVersionAliases"/></description></item>
-    ///   <item><description><see cref="NpmBumpVersionAliases"/></description></item>
+    ///   <item><description><see cref="NpmVersionAliases"/></description></item>
     /// </list>
     /// </summary>
     [CakeAliasCategory("Npm")]
-    [CakeNamespaceImport("Cake.Npm.Version")]
-    public static class NpmVersionAliases
+    [CakeNamespaceImport("Cake.Npm.BumpVersion")]
+    public static class NpmBumpVersionAliases
     {
         /// <summary>
-        /// Versions all packages for the project in the current working directory.
+        /// Bump the version of the package.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <example>
         /// <code>
         /// <![CDATA[
-        ///     var versionString = NpmVersion();
+        ///     NpmBumpVersion();
         /// ]]>
         /// </code>
         /// </example>
         [CakeMethodAlias]
-        [CakeAliasCategory("Version")]
-        public static string NpmVersion(this ICakeContext context)
+        [CakeAliasCategory("BumpVersion")]
+        public static void NpmBumpVersion(this ICakeContext context)
         {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
             
-            AddinInformation.LogVersionInformation(context.Log);
-            return context.NpmVersion(new NpmVersionSettings());
+            context.NpmBumpVersion(new NpmBumpVersionSettings());
         }
 
         /// <summary>
-        /// Versions all packages for the project in the current working directory
-        /// using the settings returned by a configurator.
+        /// Bump the version of the package using the settings returned by a configurator.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="configurator">The settings configurator.</param>
         /// <example>
         /// <code>
         /// <![CDATA[
-        ///     var versionString = NpmVersion(settings => settings.WithLogLevel(NpmLogLevel.Verbose));
+        ///     NpmBumpVersion(settings => 
+        ///         settings.Version("major"));
         /// ]]>
         /// </code>
         /// </example>
         [CakeMethodAlias]
-        [CakeAliasCategory("Version")]
-        public static string NpmVersion(this ICakeContext context, Action<NpmVersionSettings> configurator)
+        [CakeAliasCategory("BumpVersion")]
+        public static void NpmBumpVersion(this ICakeContext context, Action<NpmBumpVersionSettings> configurator)
         {
             if (context == null)
             {
@@ -69,29 +69,28 @@ namespace Cake.Npm
                 throw new ArgumentNullException(nameof(configurator));
             }
 
-            var settings = new NpmVersionSettings();
+            var settings = new NpmBumpVersionSettings();
             configurator(settings);
-            return context.NpmVersion(settings);
+            context.NpmBumpVersion(settings);
         }
 
         /// <summary>
-        /// Versions all packages for the project in the current working directory
-        /// using the specified settings.
+        /// Bump the version of the package using the specified settings.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="settings">The settings.</param>
         /// <example>
         /// <code>
         /// <![CDATA[
-        ///     var settings = new NpmVersionSettings();
-        ///     settings.WithLogLevel(NpmLogLevel.Verbose);
-        ///     var versionString = NpmVersion(settings);
+        ///     var settings = new NpmBumpVersionSettings();
+        ///     settings.Version = "major";
+        ///     NpmBumpVersion(settings);
         /// ]]>
         /// </code>
         /// </example>
         [CakeMethodAlias]
-        [CakeAliasCategory("Version")]
-        public static string NpmVersion(this ICakeContext context, NpmVersionSettings settings)
+        [CakeAliasCategory("BumpVersion")]
+        public static void NpmBumpVersion(this ICakeContext context, NpmBumpVersionSettings settings)
         {
             if (context == null)
             {
@@ -104,8 +103,8 @@ namespace Cake.Npm
             }
 
             AddinInformation.LogVersionInformation(context.Log);
-            var tool = new NpmVersionTool(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, context.Log);
-            return tool.Version(settings);
+            var tool = new NpmBumpVersionTool(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, context.Log);
+            tool.BumpVersion(settings);
         }
     }
 }

--- a/src/Cake.Npm/NpmViewVersionAliases.cs
+++ b/src/Cake.Npm/NpmViewVersionAliases.cs
@@ -1,37 +1,38 @@
 namespace Cake.Npm
 {
     using System;
-    using Cake.Npm.Version;
-    using Core;
-    using Core.Annotations;
+    using Cake.Core;
+    using Cake.Core.Annotations;
+    using Cake.Npm.ViewVersion;
 
     /// <summary>
-    /// Npm Version aliases.
-    /// Use this to get the current npm version in use.
+    /// Npm ViewVersion aliases.
+    /// Use this to view package versions.
     /// For other functions of npm version, see:
     /// <list type="bullet">
-    ///   <item><description><see cref="NpmViewVersionAliases"/></description></item>
+    ///   <item><description><see cref="NpmVersionAliases"/></description></item>
     ///   <item><description><see cref="NpmBumpVersionAliases"/></description></item>
     /// </list>
     /// </summary>
     [CakeAliasCategory("Npm")]
-    [CakeNamespaceImport("Cake.Npm.Version")]
-    public static class NpmVersionAliases
+    [CakeNamespaceImport("Cake.Npm.ViewVersion")]
+    public static class NpmViewVersionAliases
     {
         /// <summary>
-        /// Versions all packages for the project in the current working directory.
+        /// View the version of a package.
         /// </summary>
         /// <param name="context">The context.</param>
+        /// <param name="package">The Package.</param>
         /// <example>
         /// <code>
         /// <![CDATA[
-        ///     var versionString = NpmVersion();
+        ///     var versionString = NpmViewVersion("cakejs");
         /// ]]>
         /// </code>
         /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Version")]
-        public static string NpmVersion(this ICakeContext context)
+        public static string NpmViewVersion(this ICakeContext context, string package)
         {
             if (context == null)
             {
@@ -39,11 +40,14 @@ namespace Cake.Npm
             }
             
             AddinInformation.LogVersionInformation(context.Log);
-            return context.NpmVersion(new NpmVersionSettings());
+            return context.NpmViewVersion(new NpmViewVersionSettings
+            {
+                Package = package
+            });
         }
 
         /// <summary>
-        /// Versions all packages for the project in the current working directory
+        /// View the version of a package
         /// using the settings returned by a configurator.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -51,13 +55,14 @@ namespace Cake.Npm
         /// <example>
         /// <code>
         /// <![CDATA[
-        ///     var versionString = NpmVersion(settings => settings.WithLogLevel(NpmLogLevel.Verbose));
+        ///     var versionString = NpmViewVersion(settings => 
+        ///         settings.ForPackage("cakejs"));
         /// ]]>
         /// </code>
         /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Version")]
-        public static string NpmVersion(this ICakeContext context, Action<NpmVersionSettings> configurator)
+        public static string NpmViewVersion(this ICakeContext context, Action<NpmViewVersionSettings> configurator)
         {
             if (context == null)
             {
@@ -69,13 +74,13 @@ namespace Cake.Npm
                 throw new ArgumentNullException(nameof(configurator));
             }
 
-            var settings = new NpmVersionSettings();
+            var settings = new NpmViewVersionSettings();
             configurator(settings);
-            return context.NpmVersion(settings);
+            return context.NpmViewVersion(settings);
         }
 
         /// <summary>
-        /// Versions all packages for the project in the current working directory
+        /// View the version of a package
         /// using the specified settings.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -83,15 +88,15 @@ namespace Cake.Npm
         /// <example>
         /// <code>
         /// <![CDATA[
-        ///     var settings = new NpmVersionSettings();
-        ///     settings.WithLogLevel(NpmLogLevel.Verbose);
-        ///     var versionString = NpmVersion(settings);
+        ///     var settings = new NpmViewVersionSettings();
+        ///     settings.Package = "cakejs";
+        ///     var versionString = NpmViewVersion(settings);
         /// ]]>
         /// </code>
         /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Version")]
-        public static string NpmVersion(this ICakeContext context, NpmVersionSettings settings)
+        public static string NpmViewVersion(this ICakeContext context, NpmViewVersionSettings settings)
         {
             if (context == null)
             {
@@ -104,7 +109,7 @@ namespace Cake.Npm
             }
 
             AddinInformation.LogVersionInformation(context.Log);
-            var tool = new NpmVersionTool(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, context.Log);
+            var tool = new NpmViewVersionTool(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools, context.Log);
             return tool.Version(settings);
         }
     }

--- a/src/Cake.Npm/ViewVersion/NpmViewVersionSettings.cs
+++ b/src/Cake.Npm/ViewVersion/NpmViewVersionSettings.cs
@@ -1,0 +1,48 @@
+﻿namespace Cake.Npm.ViewVersion
+{
+    using Core;
+    using Core.IO;
+
+    using System;
+
+    /// <summary>
+    /// Contains settings used by <see cref="NpmViewVersionTool"/>.
+    /// </summary>
+    public class NpmViewVersionSettings : NpmSettings
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NpmViewVersionSettings"/> class.
+        /// </summary>
+        public NpmViewVersionSettings()
+            : base("view")
+        {
+            // Since 'NpmViewVersion' returns a string we should redirect standard output.
+            RedirectStandardOutput = true;
+            Package = "npm";
+        }
+
+        /// <summary>
+        /// Gets or sets the package to view the version of.
+        /// </summary>
+        /// <value>
+        /// The package.
+        /// </value>
+        public string Package { get; set; }
+
+        /// <summary>
+        /// Evaluates the settings and writes them to <paramref name="args"/>.
+        /// </summary>
+        /// <param name="args">The argument builder into which the settings should be written.</param>
+        protected override void EvaluateCore(ProcessArgumentBuilder args)
+        {
+            if (string.IsNullOrEmpty(Package))
+            {
+                throw new ArgumentOutOfRangeException(nameof(Package));
+            }
+
+            base.EvaluateCore(args);
+            args.Append(Package);
+            args.Append("version");
+        }
+    }
+}

--- a/src/Cake.Npm/ViewVersion/NpmViewVersionSettingsExtensions.cs
+++ b/src/Cake.Npm/ViewVersion/NpmViewVersionSettingsExtensions.cs
@@ -1,0 +1,28 @@
+﻿namespace Cake.Npm.ViewVersion
+{
+    using System;
+
+    /// <summary>
+    /// Extensions for <see cref="NpmViewVersionSettings"/>.
+    /// </summary>
+    public static class NpmViewVersionSettingsExtensions
+    {
+        /// <summary>
+        /// Sets the package to view the version of.
+        /// exists on disk.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        /// <param name="package">The package for which to view the version.</param>
+        /// <returns>The <paramref name="settings"/> instance with <see cref="NpmViewVersionSettings.Package"/> set.</returns>
+        public static NpmViewVersionSettings ForPackage(this NpmViewVersionSettings settings, string package)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            settings.Package = package;
+            return settings;
+        }
+    }
+}

--- a/src/Cake.Npm/ViewVersion/NpmViewVersionTool.cs
+++ b/src/Cake.Npm/ViewVersion/NpmViewVersionTool.cs
@@ -1,0 +1,59 @@
+﻿namespace Cake.Npm.ViewVersion
+{
+    using System;
+    using System.Linq;
+
+    using Core;
+    using Core.Diagnostics;
+    using Core.IO;
+    using Core.Tooling;
+
+    /// <summary>
+    /// Tool for viewing npm package versions.
+    /// </summary>
+    public class NpmViewVersionTool : NpmTool<NpmViewVersionSettings>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NpmViewVersionTool"/> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system.</param>
+        /// <param name="environment">The environment.</param>
+        /// <param name="processRunner">The process runner.</param>
+        /// <param name="tools">The tool locator.</param>
+        /// <param name="log">Cake log instance.</param>
+        public NpmViewVersionTool(
+            IFileSystem fileSystem,
+            ICakeEnvironment environment,
+            IProcessRunner processRunner,
+            IToolLocator tools,
+            ICakeLog log) 
+            : base(fileSystem, environment, processRunner, tools, log)
+        {
+        }
+
+        /// <summary>
+        /// Views the package version from the specified settings.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        public string Version(NpmViewVersionSettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            var versionString = string.Empty;
+
+            RunCore(settings, new ProcessSettings(), process =>
+            {
+                var processOutput = process.GetStandardOutput()?.ToList();
+                if (processOutput?.Any() ?? false)
+                {
+                    versionString = processOutput.First();
+                }
+            });
+
+            return versionString;
+        }
+    }
+}


### PR DESCRIPTION
BumpVersion to use "npm version ..." to update the version of the current package.
ViewVersion to use "npm view ... version" to get the version of some npm package.

I added two new tools/aliases because of the quite different features/commandline-args of `npm version`. 
(Also, implementing it this way will not break the existing `NpmVersionAlias`)

I have added documentation on each of the three aliases, pointing to the other two.

Not implemented is `npm ls` (which is technically also a part of `npm version`) - because I *think* with it's highly "graphical" output (it paints a dependency-tree in the commandline) it is not needed for automated builds.

fixes #96 