### PR TITLE
Build against Cake 3.0 and multi-target to .NET 6 and .NET 7

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,9 +10,9 @@ install:
   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
   - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
   - ps: Invoke-WebRequest -Uri "https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1" -OutFile "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1"
-  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 3.1.414 -InstallDir $env:DOTNET_INSTALL_DIR'
-  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 5.0.402 -InstallDir $env:DOTNET_INSTALL_DIR'
-  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 6.0.100 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 5.0.408 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 6.0.411 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 7.0.305 -InstallDir $env:DOTNET_INSTALL_DIR'
   - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
   - ps: dotnet --info
 

--- a/nuspec/nuget/Cake.Npm.nuspec
+++ b/nuspec/nuget/Cake.Npm.nuspec
@@ -18,14 +18,11 @@
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netcoreapp3.1\Cake.Npm.dll" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1\Cake.Npm.pdb" target="lib\netcoreapp3.1" />
-    <file src="netcoreapp3.1\Cake.Npm.xml" target="lib\netcoreapp3.1" />
-    <file src="net5.0\Cake.Npm.dll" target="lib\net5.0" />
-    <file src="net5.0\Cake.Npm.pdb" target="lib\net5.0" />
-    <file src="net5.0\Cake.Npm.xml" target="lib\net5.0" />
     <file src="net6.0\Cake.Npm.dll" target="lib\net6.0" />
     <file src="net6.0\Cake.Npm.pdb" target="lib\net6.0" />
     <file src="net6.0\Cake.Npm.xml" target="lib\net6.0" />
+    <file src="net7.0\Cake.Npm.dll" target="lib\net7.0" />
+    <file src="net7.0\Cake.Npm.pdb" target="lib\net7.0" />
+    <file src="net7.0\Cake.Npm.xml" target="lib\net7.0" />
   </files>
 </package>

--- a/src/Cake.Npm.Tests/Cake.Npm.Tests.csproj
+++ b/src/Cake.Npm.Tests/Cake.Npm.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="2.0.0" />
-    <PackageReference Include="Cake.Testing" Version="2.0.0" />
+    <PackageReference Include="Cake.Core" Version="3.0.0" />
+    <PackageReference Include="Cake.Testing" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Cake.Npm/Cake.Npm.csproj
+++ b/src/Cake.Npm/Cake.Npm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <AssemblyName>Cake.Npm</AssemblyName>
     <RootNamespace>Cake.Npm</RootNamespace>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
@@ -21,6 +21,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="3.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This upgrades the cake.Npm add-in to use cake 3.0.0
It also removes out-of-support .NET Core 3.1 and .NET 5.

Fixes #148
Fixes #149