### PR TITLE
(GH-143) Add support for npm version --git-tag-version argument

### DIFF
--- a/src/Cake.Npm.Tests/BumpVersion/NpmBumpVersionToolTests.cs
+++ b/src/Cake.Npm.Tests/BumpVersion/NpmBumpVersionToolTests.cs
@@ -136,6 +136,34 @@
                 Assert.Equal("version minor -m \"Bumped minor version.\"", result.Args);
             }
 
+            [Fact]
+            public void Should_Add_GitTagVersion_True_Switch()
+            {
+                // Given
+                fixture.Settings.WithVersion("11.22.33");
+                fixture.Settings.GitTagVersion = true;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("version 11.22.33 --git-tag-version=true", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_GitTagVersion_False_Switch()
+            {
+                // Given
+                fixture.Settings.WithVersion("11.22.33");
+                fixture.Settings.GitTagVersion = false;
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("version 11.22.33 --git-tag-version=false", result.Args);
+            }
+
             class ExtensionNullCheckData : IEnumerable<object[]>
             {
                 public IEnumerator<object[]> GetEnumerator()

--- a/src/Cake.Npm/BumpVersion/NpmBumpVersionSettings.cs
+++ b/src/Cake.Npm/BumpVersion/NpmBumpVersionSettings.cs
@@ -36,6 +36,12 @@
         public string Version  {get;set; }
 
         /// <summary>
+        /// Gets or sets the <c>--git-tag-version</c> option.
+        /// Tag the commit when using the <c>npm version</c> command. Setting this to <c>true</c> results in no commit being made at all.
+        /// </summary>
+        public bool? GitTagVersion { get; set; }
+
+        /// <summary>
         /// Evaluates the settings and writes them to <paramref name="args"/>.
         /// </summary>
         /// <param name="args">The argument builder into which the settings should be written.</param>
@@ -53,6 +59,12 @@
             {
                 args.Append("-f");
             }
+
+            if (GitTagVersion.HasValue)
+            {
+                args.Append($"--git-tag-version={GitTagVersion.ToString().ToLowerInvariant()}");
+            }
+
         }
     }
 }


### PR DESCRIPTION
Add support for npm version --git-tag-version=false option.

Fixes #143 