### PR TITLE
Install required .NET SDK for Wyam

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,9 @@ install:
   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
   - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
   - ps: Invoke-WebRequest -Uri "https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1" -OutFile "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1"
+  # Required for Wyam
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 2.1.818 -InstallDir $env:DOTNET_INSTALL_DIR'
+  # Required for GitVersion
   - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 5.0.408 -InstallDir $env:DOTNET_INSTALL_DIR'
   - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 6.0.411 -InstallDir $env:DOTNET_INSTALL_DIR'
   - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 7.0.305 -InstallDir $env:DOTNET_INSTALL_DIR'


### PR DESCRIPTION
Wyam requires .NET Core 2.1 to be available on AppVeyor