### PR TITLE
Add a "global" flag to npm exec

### DIFF
--- a/src/Cake.Npm/Exec/NpmExecSettings.cs
+++ b/src/Cake.Npm/Exec/NpmExecSettings.cs
@@ -30,6 +30,11 @@ public class NpmExecSettings : NpmSettings
     /// Arguments to pass to the target script.
     /// </summary>
     public IList<string> Arguments => arguments;
+    
+    /// <summary>
+    /// If the script is installed globally.
+    /// </summary>
+    public bool IsGlobal { get; set; }
 
     /// <inheritdoc />
     protected override void EvaluateCore(ProcessArgumentBuilder args)
@@ -42,6 +47,11 @@ public class NpmExecSettings : NpmSettings
         base.EvaluateCore(args);
 
         args.AppendQuoted(ExecCommand);
+
+        if (IsGlobal)
+        {
+            args.Append("--global");
+        }
 
         if (Arguments.Any())
         {


### PR DESCRIPTION
If a script is installed globally, we need to pass `--global` to `npm exec`.

This solves #183 