### PR TITLE
WIP chore: Update Cake.Npm to target Cake v6.0.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,8 +12,6 @@ install:
   - ps: Invoke-WebRequest -Uri "https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1" -OutFile "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1"
   # Required for Wyam
   - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 2.1.818 -InstallDir $env:DOTNET_INSTALL_DIR'
-  # Required for GitVersion
-  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 6.0.411 -InstallDir $env:DOTNET_INSTALL_DIR'
   - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 8.0.404 -InstallDir $env:DOTNET_INSTALL_DIR'
   - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 9.0.101 -InstallDir $env:DOTNET_INSTALL_DIR'
   - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 10.0.101 -InstallDir $env:DOTNET_INSTALL_DIR'
@@ -24,7 +22,7 @@ install:
 #  Build Script                   #
 #---------------------------------#
 build_script:
-  - ps: .\build.ps1 --target=CI
+  - ps: .\build.ps1 --target=CI --verbosity=Verbose
 
 # Tests
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,6 +16,7 @@ install:
   - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 6.0.411 -InstallDir $env:DOTNET_INSTALL_DIR'
   - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 8.0.404 -InstallDir $env:DOTNET_INSTALL_DIR'
   - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 9.0.101 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 10.0.101 -InstallDir $env:DOTNET_INSTALL_DIR'
   - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
   - ps: dotnet --info
 

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.3.0",
+      "version": "6.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/nuspec/nuget/Cake.Npm.nuspec
+++ b/nuspec/nuget/Cake.Npm.nuspec
@@ -26,5 +26,8 @@
     <file src="net9.0\Cake.Npm.dll" target="lib\net9.0" />
     <file src="net9.0\Cake.Npm.pdb" target="lib\net9.0" />
     <file src="net9.0\Cake.Npm.xml" target="lib\net9.0" />
+    <file src="net10.0\Cake.Npm.dll" target="lib\net10.0" />
+    <file src="net10.0\Cake.Npm.pdb" target="lib\net10.0" />
+    <file src="net10.0\Cake.Npm.xml" target="lib\net10.0" />
   </files>
 </package>

--- a/src/Cake.Npm.Tests/Cake.Npm.Tests.csproj
+++ b/src/Cake.Npm.Tests/Cake.Npm.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="5.0.0" />
-    <PackageReference Include="Cake.Testing" Version="5.0.0" />
+    <PackageReference Include="Cake.Core" Version="6.0.0" />
+    <PackageReference Include="Cake.Testing" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/src/Cake.Npm/Cake.Npm.csproj
+++ b/src/Cake.Npm/Cake.Npm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <AssemblyName>Cake.Npm</AssemblyName>
     <RootNamespace>Cake.Npm</RootNamespace>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
@@ -20,6 +20,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="6.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Using Cake.Npm with Cake 6.0 produces a compatibility warning because the addin still references Cake.Core 5.0.0:

`The assembly 'Cake.Npm' is referencing an older version of Cake.Core (5.0.0). For best compatibility it should target Cake.Core version 6.0.0.`

Changes
Cake.Npm.csproj — bump Cake.Core reference 5.0.0 → 6.0.0; add net10.0 to TargetFrameworks (Cake 6.0 ships net10.0 support)
Cake.Npm.Tests.csproj — bump Cake.Core + Cake.Testing 5.0.0 → 6.0.0; add net10.0 TFM
Cake.Npm.nuspec — add net10.0 lib entries for dll/pdb/xml

Closes #190 