### PR TITLE
Add support for `--if-present` to NpmRunScript settings and tests

### DIFF
--- a/src/Cake.Npm.Tests/RunScript/NpmScriptRunnerTests.cs
+++ b/src/Cake.Npm.Tests/RunScript/NpmScriptRunnerTests.cs
@@ -63,6 +63,38 @@ public class NpmScriptRunnerTests
             Assert.Equal("run-script \"foo bar\"", result.Args);
         }
 
+        
+        [Fact]
+        public void Should_Add_IfPresent_If_Specified()
+        {
+            // Given
+            var fixture = new NpmRunScriptFixture();
+            fixture.Settings.ScriptName = "foo bar";
+            fixture.Settings.IfPresent = true;
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal("run-script \"foo bar\" --if-present", result.Args);
+        }
+        
+        [Fact]
+        public void Should_Add_IfPresent_and_Arguments_If_Specified()
+        {
+            // Given
+            var fixture = new NpmRunScriptFixture();
+            fixture.Settings.ScriptName = "foo bar";
+            fixture.Settings.IfPresent = true;
+            fixture.Settings.Arguments.Add("--foo=bar");
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal("run-script \"foo bar\" --if-present -- --foo=bar", result.Args);
+        }
+        
         [Fact]
         public void Should_Add_ScriptArguments_To_Arguments_If_Not_Empty()
         {

--- a/src/Cake.Npm/RunScript/NpmRunScriptSettings.cs
+++ b/src/Cake.Npm/RunScript/NpmRunScriptSettings.cs
@@ -27,9 +27,15 @@ public class NpmRunScriptSettings : NpmSettings
     public string ScriptName { get; set; }
 
     /// <summary>
+    /// If true, the script will only be executed if it is present in package.json.
+    /// </summary>
+    public bool IfPresent { get; set; }
+    
+    /// <summary>
     /// Arguments to pass to the target script.
     /// </summary>
     public IList<string> Arguments => _arguments;
+
 
     /// <summary>
     /// Evaluates the settings and writes them to <paramref name="args"/>.
@@ -45,6 +51,11 @@ public class NpmRunScriptSettings : NpmSettings
         base.EvaluateCore(args);
 
         args.AppendQuoted(ScriptName);
+        
+        if (IfPresent)
+        {
+            args.Append("--if-present");
+        }
 
         if (Arguments.Any())
         {


### PR DESCRIPTION
Add support for IfPresent to the RunScript command. 

Test have been added and pass
<img width="764" height="120" alt="image" src="https://github.com/user-attachments/assets/59622b5d-c04f-4082-bab5-7c3608e4b9cb" />

#197 